### PR TITLE
Remove useless .coveralls.yml file

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-repo_token: FnYVvbBYjHrMvzhoYFc0MVrJ5pH5ReJL8
-


### PR DESCRIPTION
Hi,

This file isn't useful if your repo is public and it's not really SAFE to commit it. 

Regards,