### PR TITLE
chore(handlers/graphql.go) remove GET, OPTIONS, PUT, DELETE allowed m…

### DIFF
--- a/handlers/graphql.go
+++ b/handlers/graphql.go
@@ -38,7 +38,7 @@ func ExecuteQuery(query QueryStruct, schema graphql.Schema, ctx context.Context)
 
 func GraphqlHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "https://app.callisto.com")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set("Access-Control-Allow-Headers",
 		"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")


### PR DESCRIPTION
Hi,

Why allowing GET, OPTIONS, PUT, DELETE HTTPS methods if you only use POST ?

Regards